### PR TITLE
Halt on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function encrypt(account, key) {
         var encryptedMessage = crypto.AES.encrypt(JSON.stringify(account), key).toString();
         return encryptedMessage;
     } catch (e) {
-        console.log("Unable to encrypt account.");
+        throw new Error("Unable to encrypt account.");
     }
 }
 
@@ -32,7 +32,7 @@ function decrypt(string, key) {
         var decryptedMessage = JSON.parse(bytes.toString(crypto.enc.Utf8));
         return decryptedMessage;
     } catch (e) {
-        console.log("Unable to decrpty account.");
+        throw new Error("Unable to decrypt account.");
     }
 }
 


### PR DESCRIPTION
Thanks for sharing this repo. I was going to write a portable password manager for myself but discovered this piece of code that is pretty similar to what I was going to write.

**Affected functionality:**
Throw errors to halt the application instead of attempting to continue. This means the program won't attempt to continue after a failure like it does with the console logs.

Before:
![msg1](https://user-images.githubusercontent.com/2344456/29254483-0cfa6aca-8064-11e7-9d94-eb813e65542e.png)

After (notice it exits the loop instead of assuming the decryption was successful):
![msg2](https://user-images.githubusercontent.com/2344456/29254486-1384ed34-8064-11e7-8b35-8b030cc7ac85.png)

**Alternative approach:**
If the intention was to print the message without showing any stack trace, it would also make sense to do the console.log() and return if decrypt() provides a null value.
Let me know what you preferred and if you want the PR adjusted.